### PR TITLE
Fix project url in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(name='keepass_getter',
       version='1.0.0',
       description='Python library to retrieve passwords from CLI & Python using KeepassHTTP',
-      url='https://github.com/M-Gregoire/keepass-getter',
+      url='https://github.com/M-Gregoire/keepass_getter',
       author='Grégoire Martinache',
       license='Apache-2.0',
       packages=['keepass_getter'],


### PR DESCRIPTION
This URL is used on pypi.org page of this project.